### PR TITLE
Prevent arrow from blocking underlying elements

### DIFF
--- a/src/CurvedArrow.js
+++ b/src/CurvedArrow.js
@@ -113,6 +113,7 @@ class CurvedArrow extends React.PureComponent {
           var p2y = settings.p2y - y_min;
 
           canvas.style.position = "absolute";
+          canvas.style.pointerEvents = "none";
           canvas.style.top = y_min + "px";
           canvas.style.left = x_min + "px";
           canvas.width = x_max - x_min;


### PR DESCRIPTION
Set `style.pointerEvents` to `none` to prevent the canvas element from capturing mouse events. This will allow the arrow to lay on top of buttons but still have the button be completely clickable.