### PR TITLE
Prevent rendering on server side to stop crashes

### DIFF
--- a/src/CurvedArrow.js
+++ b/src/CurvedArrow.js
@@ -21,6 +21,10 @@ function quadraticCurveMinMax(p0, p1, p2) {
   }
   return [Math.round(min), Math.round(max)];
 }
+function isServerSide() {
+  return typeof window === 'undefined'
+}
+
 class CurvedArrow extends React.PureComponent {
   componentWillUnmount() {
     if (this.timer) clearTimeout(this.timer);
@@ -43,6 +47,8 @@ class CurvedArrow extends React.PureComponent {
       dynamicUpdate = false,
       zIndex = 0
     } = this.props;
+    
+    if (isServerSide()) { return null }
 
     const fromElement = document.querySelector(fromSelector);
     const toElement = document.querySelector(toSelector);


### PR DESCRIPTION
This is a quick & simple 1-minute fix to prevent crashes when loading the library on the server side.
This should work with frameworks such as NextJS.