### PR TITLE
Hide arrow when window width is lower then given amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ import CurvedArrow from "react-curved-arrow";
 |middleY|number|Middle point Y position.|0|
 |width|number|Width of the arrow and arrowhead.|8|
 |color|color|Color of the arrow and arrowhead.|"black"|
+|hideUnderWidth|number|Optional. if the window width is lower then hideUnderWidth, then arrow will be hidden (display none).|0|
 |hideIfFoundSelector|DOM selector|Optional. if the arrow can find this selector, it will hide itself. Useful for product tours when you only want to show an arrow whenever a user hasn't performed an action yet such as opening a menu.||
 |debugLine|boolean|Show debug dots and lines for fromOffset, toOffset and middle vectors.|false|
 |dynamicUpdate|boolean|Automatically adjust the arrow whenever the from/to DOM elements update. Useful for dynamic content such as sliding menus or content that is within a scrolling container.|false|

--- a/src/CurvedArrow.js
+++ b/src/CurvedArrow.js
@@ -42,6 +42,7 @@ class CurvedArrow extends React.PureComponent {
       middleY = 0,
       width = 8,
       color = "black",
+      hideUnderWidth = 0,
       hideIfFoundSelector,
       debugLine = false,
       dynamicUpdate = false,
@@ -133,6 +134,14 @@ class CurvedArrow extends React.PureComponent {
           canvas.style.left = x_min + "px";
           canvas.width = x_max - x_min;
           canvas.height = y_max - y_min;
+
+          if (hideUnderWidth > 0) {
+            if (window.matchMedia(`(max-width: ${hideUnderWidth}px)`).matches) {
+              canvas.style.display = "none";
+            } else {
+              canvas.style.display = "inline-block";
+            }
+          }
 
           if (zIndex) {
             canvas.style.zIndex = zIndex;


### PR DESCRIPTION
Simple implementation of some sort of responsiveness. 

Set `hideUnderWidth` to `800` for example to hide the arrow on smaller screens (equal or lower then 800).